### PR TITLE
Moving to STM32F1 implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,9 @@ panic-halt = "0.2"
 # Uncomment for the device example.
 # Update `memory.x`, set target to `thumbv7em-none-eabihf` in `.cargo/config`,
 # and then use `cargo build --examples device` to build it.
-[dependencies.stm32f3]
-features = ["stm32f303", "rt"]
-version = "0.11"
+[dependencies.stm32f1xx-hal]
+features = ["stm32f103", "rt"]
+version = "0.6.1"
 
 # this lets you use `cargo fix`!
 [[bin]]

--- a/openocd.cfg
+++ b/openocd.cfg
@@ -4,9 +4,9 @@
 # interfaces. At any time only one interface should be commented out.
 
 # Revision C (newer revision)
-source [find interface/stlink-v2-1.cfg]
+# source [find interface/stlink-v3.cfg]
 
 # Revision A and B (older revisions)
-# source [find interface/stlink-v2.cfg]
+source [find interface/stlink-v2.cfg]
 
-source [find target/stm32f3x.cfg]
+source [find target/stm32f1x.cfg]


### PR DESCRIPTION
- Using the stm32f1xx-hal for interfacing with the new hardware for the
  atomic clock, so this is basically a rewrite of the entire
  application.
- Added error checking for misplaced sync signals and for invalid data
  in the WWVB frame.